### PR TITLE
Enhanced accessibility using text shadows

### DIFF
--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -3,6 +3,7 @@
   min-height: 100vh;
   padding: 10px 30px;
   color: rgb(215 220 218);
+  text-shadow:0px 0px 3px black;
 }
 
 .mainBox {
@@ -64,6 +65,7 @@
 a {
   color: white;
   text-decoration: none;
+  text-shadow:0px 0px 3px black;
   font-size: 1rem;
 }
 


### PR DESCRIPTION
This is what the website looks on smaller screens:

![image](https://user-images.githubusercontent.com/59679281/193480055-1b0f245d-bbf5-44a9-b44f-e1c7364eb72f.png)

White on white makes it difficult to read so I have added black text-shadow for the white text with 3px blur.

Final Result:

![image](https://user-images.githubusercontent.com/59679281/193480145-230772a8-4995-45c0-bf41-d107c721c49d.png)

