### PR TITLE
#70 - WCAG 2 level AA color contrast recommendation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
+        "color-contrast": "^1.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.4.1",
@@ -5934,6 +5935,17 @@
       "dependencies": {
         "color-convert": "^1.9.3",
         "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/color-contrast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/color-contrast/-/color-contrast-1.0.0.tgz",
+      "integrity": "sha512-KmBPaZwdpVE84EZjvKiJjMZj8U7ZBEDOJ8W90IgjIZRjqdhMf3rfwnpW1lM2GHuGz3Mk/0SYpOvf31AwEh1H6A==",
+      "dependencies": {
+        "onecolor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/color-convert": {
@@ -14192,6 +14204,14 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onecolor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.1.0.tgz",
+      "integrity": "sha512-YZSypViXzu3ul5LMu/m6XjJ9ol8qAy9S2VjHl5E6UlhUH1KGKWabyEJifn0Jjpw23bYDzC2ucKMPGiH5kfwSGQ==",
+      "engines": {
+        "node": ">=0.4.8"
       }
     },
     "node_modules/onetime": {
@@ -25893,6 +25913,14 @@
         "color-string": "^1.6.0"
       }
     },
+    "color-contrast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/color-contrast/-/color-contrast-1.0.0.tgz",
+      "integrity": "sha512-KmBPaZwdpVE84EZjvKiJjMZj8U7ZBEDOJ8W90IgjIZRjqdhMf3rfwnpW1lM2GHuGz3Mk/0SYpOvf31AwEh1H6A==",
+      "requires": {
+        "onecolor": "^3.1.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -32167,6 +32195,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "onecolor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.1.0.tgz",
+      "integrity": "sha512-YZSypViXzu3ul5LMu/m6XjJ9ol8qAy9S2VjHl5E6UlhUH1KGKWabyEJifn0Jjpw23bYDzC2ucKMPGiH5kfwSGQ=="
     },
     "onetime": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
+    "color-contrast": "^1.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.4.1",

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -201,9 +201,18 @@ button:hover:before {
   background-color: #1f2937;
   padding: 2% 5%;
   color: white;
+  font-weight: 400;
+}
+
+.recommended {
+  color: green;
   font-weight: 600;
 }
 
+.notRecommended {
+  color: red;
+  font-weight: 600;
+}
 
 
 /*footer styles*/

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from "react";
+import colorContrast from "color-contrast";
 import "./Home.css";
 
 export default function Home() {
-  const [color, setColor] = useState("rgb(215 220 218)");
-  const [background, setBackground] = useState("rgb(17, 24, 39)");
+  const [color, setColor] = useState("#d7dcda");
+  const [background, setBackground] = useState("#111827");
+  const contrastRatio = colorContrast(color, background).toFixed(1);
 
   useEffect(() => {
     console.log(color);
@@ -68,13 +70,19 @@ export default function Home() {
                   <p>{background}</p>
                 </div>
                 <button
-                  onClick={() => navigator.clipboard.writeText(background)}>
+                  onClick={() => navigator.clipboard.writeText(background)}
+                >
                   Copy Me!
                 </button>
               </div>
-              <div
-                className="bg">
-                <div className="text" style={{ backgroundColor: `${background}`, color: `${color}` }}>
+              <div className="bg">
+                <div
+                  className="text"
+                  style={{
+                    backgroundColor: `${background}`,
+                    color: `${color}`,
+                  }}
+                >
                   <h2 id="one">Read This Message</h2>
                   <p id="two">
                     When you work for peace or any other aspect of social
@@ -90,6 +98,22 @@ export default function Home() {
                   Can You Read The Message Above Comfortably With This
                   Background? If Yes, Then Copy The Color Code. Else Try
                   Changing Colors.
+                  <p>
+                    WCAG 2.0 level AA requires a contrast ratio of at least
+                    4.5:1 for normal text and 3:1 for large text.
+                  </p>
+                  <p>
+                    Your current selection has contrast ratio of{" "}
+                    {contrastRatio >= 4.5 ? (
+                      <span className="recommended">
+                        {contrastRatio} (Recommended for normal text)
+                      </span>
+                    ) : (
+                      <span className="notRecommended">
+                        {contrastRatio} (Not Recommended for normal text)
+                      </span>
+                    )}
+                  </p>
                 </p>
               </div>
             </div>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -79,45 +79,24 @@ export default function Home() {
                   Copy Me!
                 </button>
               </div>
-              <div className="bg">
-                <div
-                  className="text"
-                  style={{
-                    backgroundColor: `${background}`,
-                    color: `${color}`,
-                  }}
-                >
-                  <h2 id="one">Read This Message</h2>
-                  <p id="two">
-                    When you work for peace or any other aspect of social
-                    change, there are often hardships to overcome. You must
-                    believe deeply that what you are doing is right, or else you
-                    may become discouraged and give up. I have found that there
-                    are no easy solutions to problems involving social change.
-                    When you commit yourself to creating a better world, you are
-                    most likely committing yourself to a lifetime of effort.
-                  </p>
-                </div>
-                <p id="message">
-                  Can You Read The Message Above Comfortably With This
-                  Background? If Yes, Then Copy The Color Code. Else Try
-                  Changing Colors.
-                  <p>
-                    WCAG 2.0 level AA requires a contrast ratio of at least
-                    4.5:1 for normal text and 3:1 for large text.
-                  </p>
-                  <p>
-                    Your current selection has contrast ratio of{" "}
-                    {contrastRatio >= 4.5 ? (
-                      <span className="recommended">
-                        {contrastRatio} (Recommended for normal text)
-                      </span>
-                    ) : (
-                      <span className="notRecommended">
-                        {contrastRatio} (Not Recommended for normal text)
-                      </span>
-                    )}
-                  </p>
+            </div>
+          </div>
+
+          <div className="bg">
+            <div className="container">
+              <div
+                className="text"
+                style={{ backgroundColor: `${background}`, color: `${color}` }}
+              >
+                <h2 id="one">Read This Message</h2>
+                <p id="two">
+                  When you work for peace or any other aspect of social change,
+                  there are often hardships to overcome. You must believe deeply
+                  that what you are doing is right, or else you may become
+                  discouraged and give up. I have found that there are no easy
+                  solutions to problems involving social change. When you commit
+                  yourself to creating a better world, you are most likely
+                  committing yourself to a lifetime of effort.
                 </p>
               </div>
             </div>
@@ -125,6 +104,22 @@ export default function Home() {
               <p id="message">
                 Can You Read The Message Above Comfortably With This Background?
                 If Yes, Then Copy The Color Code. Else Try Changing Colors.
+                <p>
+                  WCAG 2.0 level AA requires a contrast ratio of at least 4.5:1
+                  for normal text and 3:1 for large text.
+                </p>
+                <p>
+                  Your current selection has contrast ratio of{" "}
+                  {contrastRatio >= 4.5 ? (
+                    <span className="recommended">
+                      {contrastRatio} (Recommended for normal text)
+                    </span>
+                  ) : (
+                    <span className="notRecommended">
+                      {contrastRatio} (Not Recommended for normal text)
+                    </span>
+                  )}
+                </p>
               </p>
             </div>
           </div>


### PR DESCRIPTION
Fixes #70 - shows WCAG 2 level color contrast message to user

### Implementation details
Added message about the contrast ratio in message section.

![image](https://user-images.githubusercontent.com/14895768/194487508-3320087d-9e3f-4aa0-95dd-ef6af0cad43e.png)
![image](https://user-images.githubusercontent.com/14895768/194487572-69fef9c8-8ec0-41bf-a2e1-5d13669353c6.png)


### Testing Steps
- Change text and background colors and observe that the contrast message should change. The recommendation text should also change based on whether the ratio is greater than 4.5.

---

Checklist:

- [x] Pull Request title is good
- [x] Commit message is good (copy the Pull Request description to the commit message)
- [x] Tested code locally
- [-] Covered by automated tests
- [ ] Approved by the author
