### PR TITLE
Corrected font size + Pointer cursor at Color input

### DIFF
--- a/src/components/color_card/color_card.jsx
+++ b/src/components/color_card/color_card.jsx
@@ -27,6 +27,7 @@ function ColorCard() {
         <ColorPickerContent>
           <h3>Select Color For Text:</h3>
           <input
+            style={{ cursor: 'pointer' }}
             type="color"
             id="text"
             defaultValue="#000000"
@@ -39,9 +40,10 @@ function ColorCard() {
         </ColorPickerContent>
       </ColorBox>
       <ColorBox>
-        <ColorPickerContent>
-          <p>Select Color For Background:</p>
+        <ColorPickerContent  style={{paddingLeft:'0',paddingRight:'0'}}>
+          <h3 style={{width:'fit-content'}}>Select Color For Background:</h3>
           <input
+            style={{ cursor: 'pointer' }}
             type="color"
             id="color"
             defaultValue="#ffffff"


### PR DESCRIPTION
### The Problem/Feature #91 #89

- Select Color For Background':" not same font size as Select "Color For Text:"
- Color input without pointer cursor on hover
 
### Implementation details

Made "Select Color For Background':" same font as Select "Color For Text:"
Added pointer cursor while hovering color input.

- Added h3 tag
- Set padding left and right to 0 of ColorPickerContent

### Testing Steps

---

Checklist:

- [ ] Pull Request title is good
- [ ] Commit message is good (copy the Pull Request description to the commit message)
- [ ] Tested code locally
- [ ] Covered by automated tests
- [ ] Approved by the author

Would appreciate it if you tagged Hacktoberfest! Thank you.😄
